### PR TITLE
feat(client): Use evdev instead of xdotools for caps lock activation

### DIFF
--- a/client.py
+++ b/client.py
@@ -79,17 +79,13 @@ elif platform.system() == "Windows":
 elif platform.system().lower().startswith("linux"):
     import shutil
     import subprocess
+    from evdev import UInput, ecodes as e
 
     def check_dependencies():
-        commands = ["xdotool"]
-        missing = []
-        for c in commands:
-            if shutil.which(c) is None:
-                missing.append(c)
+        return True
 
-        if missing:
-            l = ", ".join(missing)
-            raise NotImplementedError(f"Missing dependencies ({l}) - install xdotool using your package manager")
+    ui = UInput()
+
 
     def get_capslock_state():
         pattern = "/sys/class/leds/input*::capslock/brightness"
@@ -102,7 +98,10 @@ elif platform.system().lower().startswith("linux"):
     def set_capslock_state(enabled):
         state = get_capslock_state()
         if state != enabled:
-            subprocess.run(["xdotool", "key", "Caps_Lock+Caps_Lock"], check=True)
+            ui.write(e.EV_KEY, e.KEY_CAPSLOCK, 1)
+            ui.write(e.EV_KEY, e.KEY_CAPSLOCK, 0)
+            ui.syn()
+
 else:
     plat = platform.system()
     raise NotImplementedError(f"Unsupported platform: {plat}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "evdev>=1.8.0",
     "pyobjc-framework-quartz>=11.0 ; sys_platform == 'darwin'",
     "websockets>=14.2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pyobjc-core==11.0; sys_platform == 'darwin'
 pyobjc-framework-Cocoa==11.0; sys_platform == 'darwin'
 pyobjc-framework-Quartz==11.0; sys_platform == 'darwin'
+evdev==1.8.0; sys_platform == 'linux'
 websockets==14.2

--- a/uv.lock
+++ b/uv.lock
@@ -2,16 +2,24 @@ version = 1
 requires-python = ">=3.12"
 
 [[package]]
+name = "evdev"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/eb/b8900082a13a47bb9f69f415174d03cbf12ce95d07345722e1f4ef0e2093/evdev-1.8.0.tar.gz", hash = "sha256:45598eee1ae3876a3122ca1dc0ec8049c01931672d12478b5c610afc24e47d75", size = 32557 }
+
+[[package]]
 name = "global-capslock"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "evdev" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
     { name = "websockets" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "evdev", specifier = ">=1.8.0" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'", specifier = ">=11.0" },
     { name = "websockets", specifier = ">=14.2" },
 ]


### PR DESCRIPTION
Last PR closed due to github skill issue.

Replaces xdotool dependency on linux with call to evdev. Makes setting caps lock state compositor independent. Essentially removes the need for runtime dependencies on linux when running the client.